### PR TITLE
Remove support of Alpine Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,23 +24,6 @@ matrix:
       env:
         - TARGET=container
         - IMAGE_NAME=fgtatsuro/infra-bridgehead:debian-jessie
-    - os: linux
-      dist: trusty
-      language: python
-      python: 2.7
-      services:
-        - docker
-      addons:
-        apt:
-          packages:
-          - python-pip
-      before_script:
-        - docker run -it -d --name container ${IMAGE_NAME} /bin/sh
-      after_script:
-        - docker rm -f container
-      env:
-        - TARGET=container
-        - IMAGE_NAME=fgtatsuro/infra-bridgehead:alpine-3.3
 
 # This role needs sudo, thus we can't use the new container infrastructure
 # sudo: false

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Requirements
 The dependencies on other softwares/librarys for this role.
 
 - Debian
-- Alpine Linux
 - OSX
   - Homebrew (>= 0.9.5)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
   galaxy_tags:
     - development
     - osx
-    - alpine
 
 # dependencies: []
 dependencies:

--- a/spec/ndenv_spec.rb
+++ b/spec/ndenv_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper_#{ENV['SPEC_TARGET_BACKEND']}"
 
-#describe command("/bin/bash -lc 'ndenv versions'"), :if => ['debian', 'alpine'].include?(os[:family]) do
 describe command("/bin/bash -lc 'ndenv versions'") do
   its(:stdout) { should contain('v0.10.40') }
   its(:stdout) { should contain('v0.12.4') }

--- a/tasks/Alpine.yml
+++ b/tasks/Alpine.yml
@@ -1,2 +1,0 @@
----
-# tasks file for ndenv(On Alpine Linux)


### PR DESCRIPTION
Binary installed by ndenv can't be used on Alpine Linux due to the
differences between glibc and musl.

Ref.
- https://github.com/mini-containers/base/issues/5
- https://gist.github.com/FGtatsuro/27c6dc6fa55775500aa42568e20d6107
