### PR TITLE
Refactor tasks to switch user without remote_user.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,23 @@ matrix:
       dist: trusty
       language: python
       python: 2.7
+      addons:
+        apt:
+          packages:
+          - python-pip
+      before_script:
+        - sudo groupadd jenkins
+        - sudo useradd -s /bin/bash -d /home/jenkins -m -g jenkins jenkins
+        - sudo pip install ansible
+        - ansible-galaxy install -r role_requirements.yml
+        - bundle install
+      env:
+        - TARGET=localhost_linux
+        - EXTRA_VARS="anyenv_home='/home/travis' anyenv_owner='travis' anyenv_group='travis' anyenv_profile='.bash_profile'"
+    - os: linux
+      dist: trusty
+      language: python
+      python: 2.7
       services:
         - docker
       addons:

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,12 @@ namespace :spec do
       :anyenv_home  => '/Users/travis'
     },
     {
+      :name     =>  'localhost_linux',
+      :backend  =>  'exec',
+      :anyenv_owner => 'jenkins',
+      :anyenv_home  => '/home/travis'
+    },
+    {
       :name     =>  'container',
       :backend  =>  'docker',
       :anyenv_owner => 'root',

--- a/spec/ndenv_spec.rb
+++ b/spec/ndenv_spec.rb
@@ -1,16 +1,16 @@
 require "spec_helper_#{ENV['SPEC_TARGET_BACKEND']}"
 
-describe command("su -s /bin/bash -c 'ndenv versions' - #{ENV['ANYENV_OWNER']}"), :if => os[:family] == 'debian' do
+describe command("su -s /bin/bash -c 'ndenv versions' - #{ENV['ANYENV_OWNER']}"), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:stdout) { should contain('v0.10.40') }
   its(:stdout) { should contain('v0.12.4') }
 end
 
-describe command("su -s /bin/bash -c 'ndenv global' - #{ENV['ANYENV_OWNER']}"), :if => os[:family] == 'debian' do
+describe command("su -s /bin/bash -c 'ndenv global' - #{ENV['ANYENV_OWNER']}"), :if => ['debian', 'ubuntu'].include?(os[:family])  do
   its(:stdout) { should contain('v0.10.40') }
   its(:stdout) { should_not contain('v0.12.4') }
 end
 
-describe command("su -s /bin/bash -c 'node --version' - #{ENV['ANYENV_OWNER']}"), :if => os[:family] == 'debian' do
+describe command("su -s /bin/bash -c 'node --version' - #{ENV['ANYENV_OWNER']}"), :if => ['debian', 'ubuntu'].include?(os[:family]) do
   its(:stdout) { should contain('v0.10.40') }
   its(:stdout) { should_not contain('v0.12.4') }
 end

--- a/spec/ndenv_spec.rb
+++ b/spec/ndenv_spec.rb
@@ -1,33 +1,36 @@
 require "spec_helper_#{ENV['SPEC_TARGET_BACKEND']}"
 
-describe command("su -s /bin/bash -c 'ndenv versions' - #{ENV['ANYENV_OWNER']}"), :if => ['debian', 'ubuntu'].include?(os[:family]) do
-  its(:stdout) { should contain('v0.10.40') }
-  its(:stdout) { should contain('v0.12.4') }
-end
+if ENV['TARGET_HOST'].include?('container') then
+  describe command("su -s /bin/bash -c 'ndenv versions' - #{ENV['ANYENV_OWNER']}") do
+    its(:stdout) { should contain('v0.10.40') }
+    its(:stdout) { should contain('v0.12.4') }
+  end
 
-describe command("su -s /bin/bash -c 'ndenv global' - #{ENV['ANYENV_OWNER']}"), :if => ['debian', 'ubuntu'].include?(os[:family])  do
-  its(:stdout) { should contain('v0.10.40') }
-  its(:stdout) { should_not contain('v0.12.4') }
-end
+  describe command("su -s /bin/bash -c 'ndenv global' - #{ENV['ANYENV_OWNER']}") do
+    its(:stdout) { should contain('v0.10.40') }
+    its(:stdout) { should_not contain('v0.12.4') }
+  end
 
-describe command("su -s /bin/bash -c 'node --version' - #{ENV['ANYENV_OWNER']}"), :if => ['debian', 'ubuntu'].include?(os[:family]) do
-  its(:stdout) { should contain('v0.10.40') }
-  its(:stdout) { should_not contain('v0.12.4') }
-end
+  describe command("su -s /bin/bash -c 'node --version' - #{ENV['ANYENV_OWNER']}") do
+    its(:stdout) { should contain('v0.10.40') }
+    its(:stdout) { should_not contain('v0.12.4') }
+  end
 
-describe command("/bin/bash -lc 'ndenv versions'"), :if => os[:family] == 'darwin' do
-  its(:stdout) { should contain('v0.10.40') }
-  its(:stdout) { should contain('v0.12.4') }
-end
+else
+  describe command("/bin/bash -lc 'ndenv versions'") do
+    its(:stdout) { should contain('v0.10.40') }
+    its(:stdout) { should contain('v0.12.4') }
+  end
 
-describe command("/bin/bash -lc 'ndenv global'"), :if => os[:family] == 'darwin' do
-  its(:stdout) { should contain('v0.10.40') }
-  its(:stdout) { should_not contain('v0.12.4') }
-end
+  describe command("/bin/bash -lc 'ndenv global'") do
+    its(:stdout) { should contain('v0.10.40') }
+    its(:stdout) { should_not contain('v0.12.4') }
+  end
 
-describe command("/bin/bash -lc 'node --version'"), :if => os[:family] == 'darwin' do
-  its(:stdout) { should contain('v0.10.40') }
-  its(:stdout) { should_not contain('v0.12.4') }
+  describe command("/bin/bash -lc 'node --version'") do
+    its(:stdout) { should contain('v0.10.40') }
+    its(:stdout) { should_not contain('v0.12.4') }
+  end
 end
 
 # Check whether variables of 'FGtatsuro.anyenv' affects the behavior of this role properly.

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -1,2 +1,25 @@
 ---
 # tasks file for ndenv(On OSX)
+- block:
+  - name: Check whether ndenv is installed
+    shell: "{{ ndenv_login_shell }} -lc 'ndenv versions'"
+    register: result_ndenv_versions
+    ignore_errors: yes
+    changed_when: no
+  - name: Install ndenv
+    shell: "{{ ndenv_login_shell }} -lc 'anyenv install ndenv'"
+    when: "result_ndenv_versions.rc != 0"
+  - name: Install nodejs
+    shell: "{{ ndenv_login_shell }} -lc 'ndenv install {{ item }}'"
+    when: "item not in result_ndenv_versions.stdout"
+    with_items: "{{ ndenv_node_versions }}"
+  - name: Check default version
+    shell: "{{ ndenv_login_shell }} -lc 'ndenv global'"
+    register: result_ndenv_global
+    changed_when: no
+    when: "ndenv_global_version is defined"
+  - name: Set default version
+    shell: "{{ ndenv_login_shell }} -lc 'ndenv global {{ ndenv_global_version }}'"
+    when: "ndenv_global_version is defined and ndenv_global_version not in result_ndenv_global.stdout"
+  become: yes
+  become_user: "{{ anyenv_owner }}"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,2 +1,24 @@
 ---
 # tasks file for ndenv(On Debian family)
+- block:
+  - name: Check whether ndenv is installed
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv versions' - {{ anyenv_owner }}"
+    register: result_ndenv_versions
+    ignore_errors: yes
+    changed_when: no
+  - name: Install ndenv
+    shell: "su -s {{ ndenv_login_shell }} -c 'anyenv install ndenv' - {{ anyenv_owner }}"
+    when: "result_ndenv_versions.rc != 0"
+  - name: Install nodejs
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv install {{ item }}' - {{ anyenv_owner }}"
+    when: "item not in result_ndenv_versions.stdout"
+    with_items: "{{ ndenv_node_versions }}"
+  - name: Check default version
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv global' - {{ anyenv_owner }}"
+    register: result_ndenv_global
+    changed_when: no
+    when: "ndenv_global_version is defined"
+  - name: Set default version
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv global {{ ndenv_global_version }}' - {{ anyenv_owner }}"
+    when: "ndenv_global_version is defined and ndenv_global_version not in result_ndenv_global.stdout"
+  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,25 +2,3 @@
 # tasks file for ndenv
 - name: Run specified tasks on current platform
   include: "{{ ansible_os_family }}.yml"
-- block:
-  - name: Check whether ndenv is installed
-    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv versions' - {{ anyenv_owner }}"
-    register: result_ndenv_versions
-    ignore_errors: yes
-    changed_when: no
-  - name: Install ndenv
-    shell: "su -s {{ ndenv_login_shell }} -c 'anyenv install ndenv' - {{ anyenv_owner }}"
-    when: "result_ndenv_versions.rc != 0"
-  - name: Install nodejs
-    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv install {{ item }}' - {{ anyenv_owner }}"
-    when: "item not in result_ndenv_versions.stdout"
-    with_items: "{{ ndenv_node_versions }}"
-  - name: Check default version
-    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv global' - {{ anyenv_owner }}"
-    register: result_ndenv_global
-    changed_when: no
-    when: "ndenv_global_version is defined"
-  - name: Set default version
-    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv global {{ ndenv_global_version }}' - {{ anyenv_owner }}"
-    when: "ndenv_global_version is defined and ndenv_global_version not in result_ndenv_global.stdout"
-  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,26 +4,23 @@
   include: "{{ ansible_os_family }}.yml"
 - block:
   - name: Check whether ndenv is installed
-    shell: "{{ ndenv_login_shell }} -lc 'ndenv versions'"
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv versions' - {{ anyenv_owner }}"
     register: result_ndenv_versions
     ignore_errors: yes
     changed_when: no
   - name: Install ndenv
-    shell: "{{ ndenv_login_shell }} -lc 'anyenv install ndenv'"
+    shell: "su -s {{ ndenv_login_shell }} -c 'anyenv install ndenv' - {{ anyenv_owner }}"
     when: "result_ndenv_versions.rc != 0"
   - name: Install nodejs
-    shell: "{{ ndenv_login_shell }} -lc 'ndenv install {{ item }}'"
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv install {{ item }}' - {{ anyenv_owner }}"
     when: "item not in result_ndenv_versions.stdout"
     with_items: "{{ ndenv_node_versions }}"
   - name: Check default version
-    shell: "{{ ndenv_login_shell }} -lc 'ndenv global'"
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv global' - {{ anyenv_owner }}"
     register: result_ndenv_global
     changed_when: no
     when: "ndenv_global_version is defined"
   - name: Set default version
-    shell: "{{ ndenv_login_shell }} -lc 'ndenv global {{ ndenv_global_version }}'"
+    shell: "su -s {{ ndenv_login_shell }} -c 'ndenv global {{ ndenv_global_version }}' - {{ anyenv_owner }}"
     when: "ndenv_global_version is defined and ndenv_global_version not in result_ndenv_global.stdout"
   become: yes
-  become_user: "{{ anyenv_owner }}"
-  # Ref. https://github.com/ansible/ansible/pull/13424
-  remote_user: "{{ anyenv_owner }}"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,5 +1,6 @@
 [docker_host]
 localhost       ansible_connection=local
+localhost_linux ansible_connection=local
 
 [docker_container]
 container       ansible_connection=docker


### PR DESCRIPTION
- In several cases, remote_user can't be overwritten in this role.
- Following warning occurs, but become_method doesn't work well on
  container.
  - When become_method=sudo(default), almost containers don't have sudo
    command.
  - When become_method=su, docker connection plugin of Ansible doesn't
    allow 'su' as become_method.

```
 [WARNING]: Consider using 'become', 'become_method', and 'become_user' rather than running su
```
